### PR TITLE
Add option to force verifier to guess answer

### DIFF
--- a/pvg/__init__.py
+++ b/pvg/__init__.py
@@ -23,6 +23,7 @@ from .parameters import (
     BinarificationMethodType,
     SpgVariant,
     IhvpVariant,
+    Guess,
     InteractionProtocolType,
     MinMessageRoundsSchedulerType,
     AgentUpdateSchedule,

--- a/pvg/parameters.py
+++ b/pvg/parameters.py
@@ -88,6 +88,14 @@ class IhvpVariant(StrEnum):
     NYSTROM = enum_auto()
 
 
+class Guess(StrEnum):
+    """Enum for the possible guesses of the verifier in binary cases."""
+
+    ZERO = enum_auto()
+    ONE = enum_auto()
+    Y = enum_auto()
+
+
 class TrainerType(StrEnum):
     """Enum for the RL trainer to use."""
 
@@ -980,6 +988,9 @@ class CommonProtocolParameters(SubParameters):
     shared_reward : bool
         Whether to use a shared reward function, where the prover gets the same reward
         as the verifier. This overrides `prover_reward`.
+    force_guess: Guess, optional
+        The guess to force the verifier to make. If not provided, the
+        verifier makes a guess using its policy.
     """
 
     prover_reward: float = 1.0
@@ -988,10 +999,11 @@ class CommonProtocolParameters(SubParameters):
     verifier_terminated_penalty: float = -1.0
     verifier_no_guess_reward: float = 0.0
     shared_reward: bool = False
+    force_guess: Optional[Guess] = None
 
 
 @dataclass
-class LongProtocolParameters(SubParameters, ABC):
+class LongProtocolParameters(CommonProtocolParameters, ABC):
     """Additional parameters for interaction protocols with multiple rounds.
 
     Parameters

--- a/pvg/protocols.py
+++ b/pvg/protocols.py
@@ -15,9 +15,10 @@ from torch import Tensor
 
 from tensordict.tensordict import TensorDict, TensorDictBase
 
+from typing import Optional
 from jaxtyping import Int, Bool, Float
 
-from pvg.parameters import Parameters, InteractionProtocolType
+from pvg.parameters import Parameters, InteractionProtocolType, Guess
 
 
 class ProtocolHandler(ABC):
@@ -172,6 +173,14 @@ class ProtocolHandler(ABC):
 
         # If the verifier has made a guess we terminate the episode
         verifier_index = (..., self.agent_names.index("verifier"))
+
+        if self.params.pvg_protocol.force_guess == Guess.ONE:
+            decision[verifier_index] = torch.ones_like(decision[verifier_index])
+        elif self.params.pvg_protocol.force_guess == Guess.ZERO:
+            decision[verifier_index] = torch.zeros_like(decision[verifier_index])
+        elif self.params.pvg_protocol.force_guess == Guess.Y:
+            decision[verifier_index] = env_td["y"].squeeze()
+
         verifier_decision_made = verifier_turn_mask & (decision[verifier_index] != 2)
         verifier_decision_made = verifier_decision_made & (
             round >= self.min_message_rounds

--- a/scripts/dummy_test_gi.py
+++ b/scripts/dummy_test_gi.py
@@ -17,6 +17,7 @@ from pvg import (
     CommonProtocolParameters,
     PvgProtocolParameters,
     PpoLossType,
+    Guess,
     run_experiment,
 )
 from pvg.constants import WANDB_PROJECT, WANDB_ENTITY
@@ -43,12 +44,14 @@ def run(cmd_args: Namespace):
                 num_transformer_layers=1,
                 normalize_message_history=True,
                 use_manual_architecture=False,
+                agent_lr_factor={"actor": 0.0, "critic": 1.0},
             ),
             prover=GraphIsomorphismAgentParameters(
                 num_gnn_layers=1,
                 num_transformer_layers=1,
                 normalize_message_history=True,
                 use_manual_architecture=False,
+                agent_lr_factor={"actor": 1.0, "critic": 1.0},
             ),
         ),
         rl=RlTrainerParameters(
@@ -56,10 +59,11 @@ def run(cmd_args: Namespace):
             num_epochs=1,
             minibatch_size=4,
             frames_per_batch=16,
-            use_shared_body=True,
+            use_shared_body=False,
         ),
         ppo=CommonPpoParameters(
             loss_type=PpoLossType.CLIP,
+            normalize_advantage=True,
         ),
         reinforce=ReinforceParameters(
             use_advantage_and_critic=False,
@@ -69,6 +73,7 @@ def run(cmd_args: Namespace):
         ),
         pvg_protocol=PvgProtocolParameters(
             min_message_rounds=0,
+            # force_guess=Guess.Y
         ),
         pretrain_agents=False,
     )

--- a/scripts/ppo_gi.py
+++ b/scripts/ppo_gi.py
@@ -20,6 +20,7 @@ from pvg import (
     ActivationType,
     SpgVariant,
     IhvpVariant,
+    Guess,
     CommonProtocolParameters,
     PvgProtocolParameters,
     ConstantUpdateSchedule,

--- a/scripts/ppo_ic.py
+++ b/scripts/ppo_ic.py
@@ -24,6 +24,7 @@ from pvg import (
     PvgProtocolParameters,
     SpgVariant,
     IhvpVariant,
+    Guess,
     run_experiment,
     prepare_experiment,
 )


### PR DESCRIPTION
Aside from the obvious changes, one thing worth noting is that `LongProtocolParameters` now inherits from `CommonProtocolParameters` instead of `SubParameters` (though `CommonProtocolParameters` inherits from `SubParameters`, so I assume this is fine).