### PR TITLE
Enabled sharing pure-text model

### DIFF
--- a/pvg/parameters/__init__.py
+++ b/pvg/parameters/__init__.py
@@ -81,6 +81,7 @@ from .agents import (
     RandomAgentParameters,
     GraphIsomorphismAgentParameters,
     ImageClassificationAgentParameters,
+    PureTextAgentParameters,
     CodeValidationAgentParameters,
     AgentsParameters,
 )

--- a/pvg/parameters/agents.py
+++ b/pvg/parameters/agents.py
@@ -409,10 +409,9 @@ class ImageClassificationAgentParameters(AgentParameters):
         )
 
 
-@register_parameter_class
 @dataclass
-class CodeValidationAgentParameters(AgentParameters):
-    """Additional parameters for agents in the code validation experiment.
+class PureTextAgentParameters(AgentParameters):
+    """Additional parameters for text-based agents who use APIs to generate responses.
 
     Parameters
     ----------
@@ -423,6 +422,12 @@ class CodeValidationAgentParameters(AgentParameters):
     use_dummy_api : bool
         Whether to use a dummy API instead of the real API. This is useful for testing
         the agent without making real API requests.
+    shared_model_group : str | None
+        The group of agents which share the same model. When two agents share this
+        value, they will use the same model inference. For fine-tuning, this model is
+        trained on a copy of the rollouts and rewards for each agent in the group. When
+        this is `None`, the agent is in a group whose name is the same as the agent's
+        name.
     temperature : float | None
         The temperature to use when sampling from the model. If `None`, the model uses
         the default temperature. Only one of `temperature` and `top_p` should be set.
@@ -449,6 +454,7 @@ class CodeValidationAgentParameters(AgentParameters):
     model_provider: Literal["OpenAI"] = "OpenAI"
     model_name: str = "gpt-4o-mini-2024-07-18"
     use_dummy_api: bool = False
+    shared_model_group: Optional[str] = None
 
     temperature: float | None = None
     top_p: float | None = None
@@ -462,8 +468,51 @@ class CodeValidationAgentParameters(AgentParameters):
     num_invalid_generation_retries: int = 5
 
     @classmethod
-    def construct_test_params(cls) -> "CodeValidationAgentParameters":
+    def construct_test_params(cls) -> "PureTextAgentParameters":
         return cls(use_dummy_api=True)
+
+
+@register_parameter_class
+@dataclass
+class CodeValidationAgentParameters(PureTextAgentParameters):
+    """Additional parameters for agents in the code validation experiment.
+
+    Parameters
+    ----------
+    model_provider : Literal["OpenAI"]
+        The provider of the model and API to use.
+    model_name : str
+        The name of the model to use.
+    use_dummy_api : bool
+        Whether to use a dummy API instead of the real API. This is useful for testing
+        the agent without making real API requests.
+    shared_model_group : str | None
+        The group of agents which share the same model. When two agents share this
+        value, they will use the same model inference. For fine-tuning, this model is
+        trained on a copy of the rollouts and rewards for each agent in the group. When
+        this is `None`, the agent is in a group on its own.
+    temperature : float | None
+        The temperature to use when sampling from the model. If `None`, the model uses
+        the default temperature. Only one of `temperature` and `top_p` should be set.
+    top_p : float | None
+        The top-p value to use when sampling from the model. A value 0.1 means only the
+        top 10% of tokens are considered when sampling. If `None`, the model uses the
+        default top-p value. Only one of `temperature` and `top_p` should be set.
+    fine_tune_from_scratch : bool
+        Whether to fine-tune the model from scratch each iteration, or continue
+        fine-tuning from the previous iteration.
+    freeze_agent : bool
+        Whether to freeze the agent (i.e. not fine-tune it).
+    max_response_words : int
+        In the system prompt, we say that the agent should respond with a message of at
+        most this many words.
+    max_tokens_per_message : int | None
+        The maximum number of tokens which the model is allowed to generate in a single
+        message. If `None`, this is calculated based on the `max_response_words`.
+    num_invalid_generation_retries : int
+        The number of times to retry generating a message if the model returns an
+        invalid response.
+    """
 
 
 @register_parameter_value_class

--- a/pvg/scenario_base/__init__.py
+++ b/pvg/scenario_base/__init__.py
@@ -28,6 +28,8 @@ from .agents import (
     TensorDictDummyAgentPartMixin,
     WholeAgent,
     PureTextWholeAgent,
+    PureTextSharedModelGroup,
+    PureTextSharedModelGroupState,
     RandomWholeAgent,
     AgentBody,
     AgentHead,

--- a/pvg/scenario_base/agents.py
+++ b/pvg/scenario_base/agents.py
@@ -30,7 +30,7 @@ from einops import repeat, rearrange
 
 from jaxtyping import Float, Int, Bool
 
-from pvg.parameters import HyperParameters
+from pvg.parameters import HyperParameters, PureTextAgentParameters
 from pvg.experiment_settings import ExperimentSettings
 from pvg.protocols import ProtocolHandler
 from pvg.scenario_base.environment import PureTextEnvironment
@@ -360,6 +360,8 @@ class WholeAgent(AgentPart, ABC):
 class PureTextWholeAgent(WholeAgent, ABC):
     """Base class for whole agents which process text input and call APIs."""
 
+    shared_model_group: Optional["PureTextSharedModelGroup"] = None
+    agent_params: PureTextAgentParameters
     _visible_message_channel_mask: Optional[Bool[np.ndarray, "channel"]] = None
 
     @cached_property
@@ -386,14 +388,157 @@ class PureTextWholeAgent(WholeAgent, ABC):
             The output of the forward pass on the input.
         """
 
+    @abstractmethod
+    def build_fine_tune_dataset(self, rollouts: NestedArrayDict) -> list:
+        """Build a dataset for fine-tuning the agent from sampled rollouts.
+
+        This method generates a dataset of examples ready to pass to the fine-tune API.
+
+        Parameters
+        ----------
+        rollouts : NestedArrayDict
+            The sampled rollouts.
+
+        Returns
+        -------
+        fine_tune_dataset : list
+            The dataset for fine-tuning the agent.
+        """
+
     def __call__(
         self, data: NestedArrayDict, environment: PureTextEnvironment
     ) -> NestedArrayDict:
         return self.forward(data, environment)
 
+
+@dataclass
+class PureTextSharedModelGroupState(ABC):
+    """Base class for storing all the data needed to restore a shared model group."""
+
+
+class PureTextSharedModelGroup(ABC):
+    """A class representing a group of pure text agents which share the same model
+
+    The shared model is fine-tuned on the data from all agents in the group.
+
+    Parameters
+    ----------
+    hyper_params : HyperParameters
+        The parameters of the experiment.
+    settings : ExperimentSettings
+        The settings of the experiment.
+    protocol_handler : ProtocolHandler
+        The protocol handler for the experiment.
+    agent_wholes : Iterable[PureTextWholeAgent]
+        The agents in the shared model group.
+    group_name : str
+        The name of the shared model group.
+    """
+
+    state_class: ClassVar[type[PureTextSharedModelGroupState]] = (
+        PureTextSharedModelGroupState
+    )
+
+    @dataclass
+    class SharedAgentParams:
+        """The parameters shared by all agents in the group."""
+
+        model_name: str
+        freeze_agent: bool
+        use_dummy_api: bool
+        fine_tune_from_scratch: bool
+
+    @property
+    def model_name(self) -> str:
+        """The current model name, which may be the base model or a fine-tuned model."""
+        if self.fine_tuned_model_name is not None:
+            return self.fine_tuned_model_name
+        else:
+            return self.base_model_name
+
+    def __init__(
+        self,
+        hyper_params: HyperParameters,
+        settings: ExperimentSettings,
+        protocol_handler: ProtocolHandler,
+        agent_wholes: Iterable[PureTextWholeAgent],
+        group_name: str,
+    ):
+        self.hyper_params = hyper_params
+        self.settings = settings
+        self.protocol_handler = protocol_handler
+        self.group_name = group_name
+
+        self.agent_wholes = {agent.agent_name: agent for agent in agent_wholes}
+        self.agent_names = list(self.agent_wholes.keys())
+
+        shared_agent_params = {}
+        for agent in agent_wholes:
+
+            # Check that the agent's shared_model_group attribute is set correctly
+            if (
+                agent.agent_params.shared_model_group is not None
+                and agent.agent_params.shared_model_group != self.group_name
+            ):
+                raise ValueError(
+                    f"Tried to create a shared model group named {group_name!r} "
+                    f"containing agent {agent.agent_name!r}, but its "
+                    f"`shared_model_group` attribute is set to "
+                    f"{agent.agent_params.shared_model_group!r}."
+                )
+            elif (
+                agent.agent_params.shared_model_group is None
+                and group_name != agent.agent_name
+            ):
+                raise ValueError(
+                    f"Tried to create a shared model group named {group_name!r} "
+                    f"containing agent {agent.agent_name!r}, but its "
+                    f"`shared_model_group` attribute is not set."
+                )
+
+            # Get the value of the shared agent parameters and check that they are the
+            # same for all agents in the group
+            for shared_agent_param_field in fields(self.SharedAgentParams):
+                param_name = shared_agent_param_field.name
+                if param_name not in shared_agent_params:
+                    shared_agent_params[param_name] = getattr(
+                        agent.agent_params, param_name
+                    )
+                elif (
+                    getattr(agent.agent_params, param_name)
+                    != shared_agent_params[param_name]
+                ):
+                    raise ValueError(
+                        f"All agents in a shared model group must have the same "
+                        f"{param_name!r} parameter, but got "
+                        f"{shared_agent_params[param_name]!r} for agent "
+                        f"{self.agent_names[0]!r} and "
+                        f"{getattr(agent.agent_params, param_name)!r} for "
+                        f"agent {agent.agent_name!r}."
+                    )
+
+            # Set the agent's shared_model_group attribute
+            if agent.shared_model_group is not None:
+                raise ValueError(
+                    f"Agent {agent.agent_name} is already in a shared model group."
+                )
+            agent.shared_model_group = self
+
+        self.shared_agent_params = self.SharedAgentParams(**shared_agent_params)
+        self.base_model_name = self.shared_agent_params.model_name
+
+        self.fine_tune_job_id: Optional[str] = None
+        self.fine_tuned_model_name: Optional[str] = None
+
     @abstractmethod
-    def create_fine_tune_job(self, data: NestedArrayDict):
-        """Create a fine-tune job for the agent given sampled rollouts"""
+    def create_fine_tune_job(self, data_per_agent: dict[str, NestedArrayDict]):
+        """Create a fine-tune job for the agent group given sampled rollouts
+
+        Parameters
+        ----------
+        data_per_agent : dict[str, NestedArrayDict]
+            The data for each agent in the group, sampled from the environment.
+        """
 
     @abstractmethod
     def get_fine_tune_job_status(
@@ -408,6 +553,37 @@ class PureTextWholeAgent(WholeAgent, ABC):
     @abstractmethod
     def switch_to_next_model(self):
         """Switch to the next model after fine-tuning"""
+
+    def set_state(self, checkpoint: PureTextSharedModelGroupState):
+        """Set the state of the shared model group from a checkpoint.
+
+        This method should be overridden by subclasses to restore the state of the
+        shared model group from a checkpoint.
+
+        Parameters
+        ----------
+        checkpoint : AgentCheckpoint
+            The checkpoint to restore the state from.
+        """
+
+    def get_state_dict(self) -> dict:
+        """Get the state of the shared model group as a dict.
+
+        This method should be implemented by subclasses capable of saving their state.
+
+        Returns
+        -------
+        state_dict : dict
+            The state of the shared model group.
+        """
+        raise NotImplementedError(
+            f"Getting the agent state is not implemented for "
+            f"{self.__class__.__name__}"
+        )
+
+    def get_state(self) -> PureTextSharedModelGroupState:
+        """Get the state of the shared model group."""
+        return self.state_class(**self.get_state_dict())
 
 
 class RandomWholeAgent(WholeAgent, ABC):

--- a/scripts/ei_cv.py
+++ b/scripts/ei_cv.py
@@ -41,6 +41,7 @@ param_grid = dict(
     prover_temperature=[None],
     prover_top_p=[None],
     freeze_prover=[False],
+    provers_share_model=[False],
     fine_tune_from_scratch=[False],
     fine_tune_on_all_previous_rollouts=[False],
     rollout_selection_method=["threshold"],
@@ -76,6 +77,11 @@ def _construct_params(combo: dict, cmd_args: Namespace) -> HyperParameters:
         freeze_agent=combo["freeze_prover"],
         fine_tune_from_scratch=combo["fine_tune_from_scratch"],
     )
+
+    if combo["provers_share_model"]:
+        prover_params_dict["shared_model_group"] = "provers_group"
+    else:
+        prover_params_dict["shared_model_group"] = None
 
     if combo["interaction_protocol"] in [
         InteractionProtocolType.PVG,


### PR DESCRIPTION
Agents can now be grouped together, so that agents in the same group share the same model and are fine-tuned together. 

Grouping can be arbitrary, and is specified by the `shared_model_group` agent parameter. When two agents agree on this parameter, they are in the same group.