### PR TITLE
Update repo name from nip-experiments to neural-interactive-proofs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -40,9 +40,9 @@ SSH_PUBKEY=
 
 # The URI of the Git repository to clone in the Docker image. If you have a private fork
 # of the repository, you can use a GitHub personal access token to authenticate. For
-# example: https://${GITHUB_USER}:${GITHUB_PAT}@github.com/${GITHUB_USER}/nip-experiments.git
+# example: https://${GITHUB_USER}:${GITHUB_PAT}@github.com/${GITHUB_USER}/neural-interactive-proofs.git
 # (required for using the Docker image)
-GIT_REPO_URI="https://github.com/SamAdamDay/nip-experiments.git"
+GIT_REPO_URI="https://github.com/SamAdamDay/neural-interactive-proofs.git"
 
 # Your git username and email, used for setting up the git configuration in the Docker
 # image (required for using the Docker image)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=secret,id=my_env,mode=0444 /bin/bash -c 'source /run/secrets/my
     && git config --global user.name "${GIT_NAME}" \
     && git config --global user.email "${GIT_EMAIL}" \
     && wandb login "${WANDB_KEY}" \
-    && git clone "${GIT_REPO_URI}" nip-experiments \
+    && git clone "${GIT_REPO_URI}" neural-interactive-proofs \
     && mkdir -p .ssh \
     && echo "${SSH_PUBKEY}" > .ssh/authorized_keys'
 
@@ -45,10 +45,10 @@ ENV PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/conda/b
 COPY docker/bin/* /usr/local/bin/
 
 # Copy .env file to the project directory
-COPY .env /root/nip-experiments
+COPY .env /root/neural-interactive-proofs
 
 # Move to the repo directory
-WORKDIR /root/nip-experiments
+WORKDIR /root/neural-interactive-proofs
 
 # Download the source code for PyTorch Image Models (timm), so we can use the training
 # scripts
@@ -56,7 +56,7 @@ RUN mkdir -p vendor
 RUN grep timm== requirements.txt \
     | sed -E --expression='s#timm==(.*)#https://github.com/huggingface/pytorch-image-models/archive/refs/tags/v\1.tar.gz#' \
     | xargs wget -qO- \
-    | tar -xzC /root/nip-experiments/vendor
+    | tar -xzC /root/neural-interactive-proofs/vendor
 
 # Install all the required packages
 RUN pip install wheel cython \

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/SamAdamDay/nip-experiments.git
+   git clone https://github.com/SamAdamDay/neural-interactive-proofs.git
    ```
 
-2. Change to the repository directory: `cd nip-experiments`
+2. Change to the repository directory: `cd neural-interactive-proofs`
 
 3. Install the requirements. If you just want to run experiments do:
 
@@ -133,7 +133,7 @@ docker build -t DOCKER_USER/DOCKER_REPO:DOCKER_TAG --target default --secret id=
 ```
 
 replacing `DOCKER_USER` with your Docker Hub username, and `DOCKER_REPO` and
-`DOCKER_TAG` suitable Docker repository and tag names (e.g. 'nip-experiments/default').
+`DOCKER_TAG` suitable Docker repository and tag names (e.g. 'neural-interactive-proofs/default').
 
 Alternatively, you can build an image with all of the datasets already downloaded. This
 will result in a much larger image, but can make the process of spinning up and running

--- a/doc/guides/installation.rst
+++ b/doc/guides/installation.rst
@@ -29,13 +29,13 @@ Installation Steps
 
    .. code-block:: bash
 
-      git clone https://github.com/SamAdamDay/nip-experiments.git
+      git clone https://github.com/SamAdamDay/neural-interactive-proofs.git
 
 2. Change to the repository directory:
 
    .. code-block:: bash
 
-      cd nip-experiments
+      cd neural-interactive-proofs
 
 3. Install the requirements:
 

--- a/docker/bin/nip-tmux.py
+++ b/docker/bin/nip-tmux.py
@@ -7,7 +7,7 @@ import torch
 from libtmux import Server
 from libtmux.constants import PaneDirection
 
-DEFAULT_BASE_DIRECTORY = "/root/nip-experiments"
+DEFAULT_BASE_DIRECTORY = "/root/neural-interactive-proofs"
 
 parser = ArgumentParser(
     description="Create or join a tmux session for running the nip project.",

--- a/nip/image_classification/agents.py
+++ b/nip/image_classification/agents.py
@@ -7,11 +7,11 @@ The structure of all agent bodies is the same:
 - An encoder layer, which takes as input the image and the message history and outputs
   the initial pixel-level encodings.
 - A sequence of `num_block_groups` groups of building blocks (e.g. convolutional
-  layers). 
-    + Each layer is followed by a non-linearity and each group by a max pooling layer. 
-    + For each group we halve the output size and double the number of channels. 
+  layers).
+    + Each layer is followed by a non-linearity and each group by a max pooling layer.
+    + For each group we halve the output size and double the number of channels.
     + The number of building blocks in each group is given by the `num_blocks_per_group`
-      parameter. 
+      parameter.
     + The output of the last group is the 'latent pixel-level' representations, which
       provides a representation for each latent pixel.
 - We add a channel to the latent pixel-level representations to represent the most
@@ -25,7 +25,7 @@ Notes
 -----
 In all dimension annotations, "channel" refers to the the message channel dimension,
 which is how different groups of agents can communicate with each other. There is a
-terminology overlap with the channel dimension in images and convolutional layers. Such 
+terminology overlap with the channel dimension in images and convolutional layers. Such
 channels are called "image_channel" or "latent_channel" to avoid confusion.
 """
 

--- a/nip/trainers/malt_pure_text.py
+++ b/nip/trainers/malt_pure_text.py
@@ -162,7 +162,7 @@ class PureTextMaltTrainer(PureTextRlTrainer):
             PureTextEnvironment,
             PureTextCombinedWhole,
             Optional[NestedArrayDict],
-        ]
+        ],
     ) -> list[NestedArrayDict]:
         """Sample rollouts for a single environment.
 

--- a/nip/trainers/rl_pure_text_base.py
+++ b/nip/trainers/rl_pure_text_base.py
@@ -680,7 +680,7 @@ class PureTextRlTrainer(Trainer, ABC):
             PureTextEnvironment,
             PureTextCombinedWhole,
             Optional[NestedArrayDict],
-        ]
+        ],
     ) -> list[NestedArrayDict]:
         """Sample rollouts for a single environment.
 

--- a/nip/trainers/trainer_base.py
+++ b/nip/trainers/trainer_base.py
@@ -674,7 +674,7 @@ class IterationContext:
 
 
 def attach_progress_bar(
-    num_iterations_func: Callable[[Trainer], int]
+    num_iterations_func: Callable[[Trainer], int],
 ) -> Callable[[Callable], Callable]:
     """Decorate a `Trainer` method to attach a progress bar.
 

--- a/nip/utils/experiments.py
+++ b/nip/utils/experiments.py
@@ -1,7 +1,7 @@
 """Experiment runners.
 
 Contains utilities for running hyperparameter experiments. These can be run either
-sequentially or in parallel using a pool of workers. 
+sequentially or in parallel using a pool of workers.
 
 The workflow is as follows:
 

--- a/playground/benchmarking.ipynb
+++ b/playground/benchmarking.ipynb
@@ -455,7 +455,7 @@
     "    \"llama-3.1-8b-instruct\",\n",
     "    # \"deepseek-chat\",\n",
     "    ]\n",
-    "SAVE_PATH = \"/root/nip-experiments/playground/benchmarking/results\"\n",
+    "SAVE_PATH = \"/root/neural-interactive-proofs/playground/benchmarking/results\"\n",
     "REASONING = [\"without_reasoning\", \"with_reasoning\"]\n",
     "DIFFICULTIES = [\"introductory\", \"interview\", \"competition\"]\n",
     "SPLITS = [\"train\", \"test\"]"


### PR DESCRIPTION
@SamAdamDay I did a `ctrl+f` on `nip-experiments` and replaced all instances with `neural-interactive-proofs` so as to keep everything up to date with the new repo name.